### PR TITLE
Update to change 1k ohm to 470 ohm.

### DIFF
--- a/en/sensor/lidar_lite.md
+++ b/en/sensor/lidar_lite.md
@@ -44,7 +44,7 @@ Pin | Lidar-Lite (v2, v3) | Pixhawk AUX Servo | Comment
 --- | ---   | --- | ---
 1   | VCC   | AUX 6 (center) | Power supply. 4.75-5.5V DC Nominal, Maximum 6V DC.
 2   | RESET | AUX 6 (bottom) | Reset line of the sensor
-3   | PWM   | AUX 5 (bottom) | PWM input of the Lidar Lite. **Needs a 1 KOhm pull-down (to GND)**
+3   | PWM   | AUX 5 (bottom) | PWM input of the Lidar Lite. **Needs a 470 Ohm pull-down (to GND), Do not use a 1 K0hm resistor.**
 4   | SCL   | - | Not connected
 5   | SDA   | - | Not connected
 6   | GND   | AUX 6 (top)    | Ground


### PR DESCRIPTION
1k ohm gives erroneous results. 470 ohm works as intended. Graphic needs to be altered (back) and Garmin's documentation is misleading as while that may be what they recommend (1k), it definitely does not work. Tested on stable, 1.8 and ~1.14 PX4 with separate power source (pwm).